### PR TITLE
Pass through startCodepoint option to webfontsGenerator

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -18,6 +18,7 @@ class IconFontPlugin {
             localCSSTemplate: fs.readFileSync(path.resolve(__dirname, 'local.css.hbs'), 'utf8'),
             auto: true,
             mergeDuplicates: false,
+            startCodepoint: 0xF101,
         }, options);
     }
 
@@ -46,6 +47,7 @@ class IconFontPlugin {
                     return callback();
                 const fontName = this.options.fontName;
                 const types = this.options.types;
+                const startCodepoint = this.options.startCodepoint;
                 webfontsGenerator({
                     files,
                     types,
@@ -53,6 +55,7 @@ class IconFontPlugin {
                     writeFiles: false,
                     dest: 'build', // Required but doesn't get used
                     fontHeight: 1000,
+                    startCodepoint: startCodepoint,
                 }, (err, result) => {
                     if (err)
                         return callback(err);

--- a/src/loader.js
+++ b/src/loader.js
@@ -13,7 +13,7 @@ function iconFontLoader(source) {
     const plugin = this.iconFontPlugin;
     const files = plugin.files;
     const md5s = plugin.md5s;
-    const START_NUM = 0xF100; // webfonts-generator start at this number
+    const START_NUM = plugin.options.startCodepoint - 1;
     const property = plugin.options.property;
     const mergeDuplicates = plugin.options.mergeDuplicates;
     const reg = new RegExp(`${property}\\s*:\\s*url\\(["']?(.*?)["']?\\);`, 'g');


### PR DESCRIPTION
For my project we have hardcoded code points in the project CSS. We are migrating to icon-font-loader but in order to keep the same code points I need to be able to send through startCodepoint.