### PR TITLE
Fix: Do not emit selectors when localCSSTemplate is empty string

### DIFF
--- a/src/postcssPlugin.js
+++ b/src/postcssPlugin.js
@@ -81,10 +81,9 @@ module.exports = postcss.plugin('icon-font-parser', ({ loaderContext }) => (styl
                 fontSelectors.push(rule.selector);
         });
 
-        if (fontSelectors.length) {
-            let localCSS = template({ fontName: plugin.options.fontName });
-            localCSS = `${fontSelectors.join(',')} {${localCSS}\n}`;
-            styles.insertBefore(styles.first, localCSS);
+        const localCSS = template({ fontName: plugin.options.fontName });
+        if (fontSelectors.length && localCSS !== '') {
+            styles.insertBefore(styles.first, `${fontSelectors.join(',')} {${localCSS}\n}`);
         }
     });
 });


### PR DESCRIPTION
Hi and thanks for this useful plugin/loader combo :)

This PR is a small fix to not emit any local css if the `localCSSTemplate` is an empty string.

The main use case for providing an empty template is to avoid a long list of selectors, which often can be deeply nested and instead opt for a single utility class, e.g `.icon`. 

If you would like, I could update the PR to also introduce a new option to overwrite the css selectors (e.g `localCSSSelector` which is used instead of `fontSelectors.join(',')` ), but for now I tried to keep the changes to a minimum and just render nothing when the template is empty

Thanks again